### PR TITLE
Add step for building on linux, Add copy flag into readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,15 @@ jobs:
           mkdir -p dist/darwin_amd64
           GOOS=darwin GOARCH=amd64 go build -o dist/darwin_amd64/passgen .
           (cd dist/darwin_amd64 && zip -q ../passgen_darwin_amd64.zip passgen)
+          mkdir -p dist/linux_amd64
+          GOOS=linux GOARCH=amd64 go build -o dist/linux_amd64/passgen .
+          (cd dist/linux_amd64 && zip -q ../passgen_linux_amd64.zip passgen)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: passgen
-          path: dist/passgen
+          path: dist/passgen*
 
       - name: Create release and upload asset
         if: startsWith(github.ref, 'refs/tags/')
@@ -40,3 +43,4 @@ jobs:
           files: |
             dist/passgen
             dist/passgen_darwin_amd64.zip
+            dist/passgen_linux_amd64.zip

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ passgen -len 20 -symbols -exclude "@$"
 
 # exclude ambiguous characters (0 O 1 l I)
 passgen -len 16 -no-ambiguous
+
+# copy generated passwords to clipboard
+passgen -len 20 -count 3 -copy
 ```
 
 ## Command Surface
@@ -36,6 +39,7 @@ passgen -len 16 -no-ambiguous
 - **Count:** `-count <n>`
 - **Exclude chars:** `-exclude "..."`
 - **No ambiguous:** `-no-ambiguous`
+- **Copy to clipboard:** `-copy`
 - **Help:** `-h` / `-help`
 
 ## Configuration
@@ -43,3 +47,4 @@ No config file. All behavior is controlled via CLI flags.
 
 ## Notes
 - Errors are printed to stderr and exit with code 1 on invalid input.
+- `-copy` uses `pbcopy` (macOS), `clip` (Windows), or `wl-copy`/`xclip` (Linux).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard copy functionality now available with cross-platform clipboard utility support
  * Linux binary builds now included in release assets for distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->