### PR TITLE
Add build for linux arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
           mkdir -p dist/linux_amd64
           GOOS=linux GOARCH=amd64 go build -o dist/linux_amd64/passgen .
           (cd dist/linux_amd64 && zip -q ../passgen_linux_amd64.zip passgen)
+          mkdir -p dist/linux_arm64
+          GOOS=linux GOARCH=arm64 go build -o dist/linux_arm64/passgen .
+          (cd dist/linux_arm64 && zip -q ../passgen_linux_arm64.zip passgen)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -44,3 +47,4 @@ jobs:
             dist/passgen
             dist/passgen_darwin_amd64.zip
             dist/passgen_linux_amd64.zip
+            dist/passgen_linux_arm64.zip


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Linux ARM64 architecture support to the continuous integration build pipeline. Release artifacts for this platform will now be available for download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->