### PR TITLE
Feature: Add terminal QR code generation support for passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ passgen -len 16 -no-ambiguous
 
 # copy generated passwords to clipboard
 passgen -len 20 -count 3 -copy
+
+# render first password as QR code in terminal (requires -count 1)
+passgen -len 20 -qr
 ```
 
 ## Command Surface
@@ -62,6 +65,7 @@ passgen -len 20 -count 3 -copy
 - **Exclude chars:** `-exclude "..."`
 - **No ambiguous:** `-no-ambiguous`
 - **Copy to clipboard:** `-copy`
+- **QR code:** `-qr` (only when `-count 1`)
 - **Help:** `-h` / `-help`
 
 ## Configuration

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module passgen
 
 go 1.25.6
+
+require github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"github.com/skip2/go-qrcode"
 )
 
 const (
@@ -40,6 +42,7 @@ func main() {
 	exclude := flag.String("exclude", "", "exclude specific characters")
 	noAmbiguous := flag.Bool("no-ambiguous", false, "exclude ambiguous characters like 0 O 1 l I")
 	copyOut := flag.Bool("copy", false, "copy generated passwords to clipboard")
+	qrOut := flag.Bool("qr", false, "render first password as QR code in terminal")
 	flag.Parse()
 
 	fmt.Print(banner)
@@ -49,6 +52,9 @@ func main() {
 	}
 	if *count <= 0 {
 		fatal(errors.New("-count must be greater than 0"))
+	}
+	if *qrOut && *count > 1 {
+		fatal(errors.New("-qr supports only -count=1 to avoid terminal clutter"))
 	}
 
 	if !charsetFlagsSpecified() {
@@ -81,6 +87,14 @@ func main() {
 		}
 		passwords = append(passwords, pwd)
 		fmt.Println(pwd)
+	}
+
+	if *qrOut {
+		qr, err := qrcode.New(passwords[0], qrcode.Medium)
+		if err != nil {
+			fatal(err)
+		}
+		fmt.Println(qr.ToSmallString(false))
 	}
 
 	if *copyOut {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `-qr` flag enables QR code rendering of generated passwords in the terminal. Available only when generating a single password (when `-count` is 1).

* **Documentation**
  * Updated documentation with the new `-qr` flag description and accompanying usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->